### PR TITLE
update supported LTS versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Update currently supported Node.js LTS versions for the `tests` workflow acording to https://endoflife.date/nodejs